### PR TITLE
Fix requirement category max exclusive JSON type

### DIFF
--- a/src/main/java/com/sihenzhang/crockpot/recipe/cooking/requirement/RequirementCategoryMaxExclusive.java
+++ b/src/main/java/com/sihenzhang/crockpot/recipe/cooking/requirement/RequirementCategoryMaxExclusive.java
@@ -37,7 +37,7 @@ public class RequirementCategoryMaxExclusive implements IRequirement {
     @Override
     public JsonElement toJson() {
         var obj = new JsonObject();
-        obj.addProperty("type", RequirementType.CATEGORY_MAX.name());
+        obj.addProperty("type", RequirementType.CATEGORY_MAX_EXCLUSIVE.name());
         obj.addProperty("category", category.name());
         obj.addProperty("max", max);
         return obj;


### PR DESCRIPTION
## Summary
- correct requirement type for `RequirementCategoryMaxExclusive` in `toJson`

## Testing
- `./gradlew test` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fa57c2fc08329b0ca53ec66e71605